### PR TITLE
Feature/#6 allow proxied calls to unimplemented array_* methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ php:
 before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
+  - vendor/bin/phpcs
 
 script: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ arrayed(['a' => 'www', 'b' => 'dot', 'c' => 'www'])
 > The pipe method makes use of [Piper](https://github.com/transprime-research/piper) - A PHP functional pipe'ing
 > See `\Transprime\Arrayed\Tests\ArrayedTest` 
 
+#### Proxied calls
+
+`array_*` methods that are not yet implemented are automatically proxied to call an array method with the assumption that they accept initial array first. Example is this:
+
+```php
+// ->combine() method is not yet implemented
+
+arrayed(['a', 'b'])
+    ->combine(['name', 'data'])
+    ->result(); //['a' => 'name', 'b' => 'data']
+```
+
 ## Coming Soon
 
 - Implement other `array_*` methods

--- a/src/Arrayed.php
+++ b/src/Arrayed.php
@@ -210,6 +210,6 @@ class Arrayed implements ArrayedInterface
      */
     public function jsonSerialize()
     {
-       return $this->getWorkableItem(true);
+        return $this->getWorkableItem(true);
     }
 }

--- a/src/Traits/ArrayPrefix.php
+++ b/src/Traits/ArrayPrefix.php
@@ -33,11 +33,17 @@ trait ArrayPrefix
      */
     public function __call($name, $arguments)
     {
+        // See: https://stackoverflow.com/a/57833019/5704410
         $methodName = strtolower(preg_replace("/([a-z])([A-Z])/", "$1_$2", $name));
-        $methodName = 'array_'.$methodName;
+        $methodName = 'array_' . $methodName;
 
         if (function_exists($methodName)) {
-            return $name($this->getWorkableItem(), ...$arguments);
+
+            $result = $methodName($this->getWorkableItem(), ...$arguments);
+
+            return is_array($result)
+                ? $this->setResult($result)
+                : $result;
         }
 
         throw new ArrayedException(sprintf('Method %s cannot be resolved', $name));

--- a/src/Traits/ArrayPrefix.php
+++ b/src/Traits/ArrayPrefix.php
@@ -2,6 +2,7 @@
 
 namespace Transprime\Arrayed\Traits;
 
+use Transprime\Arrayed\Exceptions\ArrayedException;
 use Transprime\Arrayed\Interfaces\ArrayedInterface;
 
 trait ArrayPrefix
@@ -19,5 +20,26 @@ trait ArrayPrefix
     public function column($column, $index_key = null): ArrayedInterface
     {
         return $this->setResult(array_column($this->getWorkableItem(), $column, $index_key));
+    }
+
+    /**
+     * Forward the calls to `array_*` that is not yet implemented
+     * <br>
+     * Assumption is for those array method that accepts the initial array as the first value
+     * @param $name
+     * @param $arguments
+     * @return mixed
+     * @throws ArrayedException
+     */
+    public function __call($name, $arguments)
+    {
+        $methodName = strtolower(preg_replace("/([a-z])([A-Z])/", "$1_$2", $name));
+        $methodName = 'array_'.$methodName;
+
+        if (function_exists($methodName)) {
+            return $name($this->getWorkableItem(), ...$arguments);
+        }
+
+        throw new ArrayedException(sprintf('Method %s cannot be resolved', $name));
     }
 }

--- a/src/Traits/ArrayPrefix.php
+++ b/src/Traits/ArrayPrefix.php
@@ -38,7 +38,6 @@ trait ArrayPrefix
         $methodName = 'array_' . $methodName;
 
         if (function_exists($methodName)) {
-
             $result = $methodName($this->getWorkableItem(), ...$arguments);
 
             return is_array($result)

--- a/tests/ArrayPrefixTraitTest.php
+++ b/tests/ArrayPrefixTraitTest.php
@@ -34,4 +34,16 @@ class ArrayPrefixTraitTest extends TestCase
             arrayed($array)->column('b')->result()
         );
     }
+
+    public function testUnImplementedArrayPrefixFunction()
+    {
+        // array_combine
+        $keys = ['a', 'b'];
+        $values = ['name', 'data'];
+
+        $this->assertEquals(
+            array_combine($keys, $values),
+            arrayed($keys)->combine($values)->result()
+        );
+    }
 }

--- a/tests/ArrayPrefixTraitTest.php
+++ b/tests/ArrayPrefixTraitTest.php
@@ -18,7 +18,7 @@ class ArrayPrefixTraitTest extends TestCase
     {
         $this->assertEquals(
             [[1,2], [3,4]],
-            arrayed(1,2,3,4)->chunk(2)->result()
+            arrayed(1, 2, 3, 4)->chunk(2)->result()
         );
     }
 

--- a/tests/ArrayedTest.php
+++ b/tests/ArrayedTest.php
@@ -309,8 +309,8 @@ class ArrayedTest extends TestCase
             'name,age',
             arrayed(['a' => 'name', 'b' => 'age'])
                 ->values()(function ($val) {
-                return implode(',', $val);
-            })
+                    return implode(',', $val);
+                })
         );
 
         $this->assertEquals(


### PR DESCRIPTION
`array_*` methods that are not yet implemented are automatically proxied to call an array method with the assumption that they accept initial array first. Example is this:

```php
// ->combine() method is not yet implemented

arrayed(['a', 'b'])
    ->combine(['name', 'data'])
    ->result(); //['a' => 'name', 'b' => 'data']
```